### PR TITLE
Fix TypeError: unhashable type: 'Taxon'`: add __hash__ method

### DIFF
--- a/taxopy/core.py
+++ b/taxopy/core.py
@@ -357,6 +357,9 @@ class Taxon:
             return NotImplemented
         return self.taxid_lineage == other.taxid_lineage
 
+    def __hash__(self) -> int:
+        return hash(self.taxid)
+
 
 class _AggregatedTaxon(Taxon):
     """


### PR DESCRIPTION
With the introduction of the `=` operator overloading with the `__eq__` method in v0.10.1, the Taxon class has become unhashable (see [here for reason why](https://www.pythontutorial.net/python-oop/python-__hash__/)).
Adding it a `__hash__` method to the class fixes it.