### PR TITLE
add list of all names to Taxon

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -69,7 +69,7 @@ To retrieve the TaxId to which a legacy TaxId has been merged, you can use the `
 >>> lagomorpha = taxopy.Taxon(9975, taxdb)
 ```
 
-Each [`Taxon`][taxopy.Taxon] object stores various data related to the taxon, including its TaxId, name, rank, and lineage. The lineage data comprises the TaxIds, names, and ranks of its parent taxa.
+Each [`Taxon`][taxopy.Taxon] object stores various data related to the taxon, including its TaxId, names, rank, and lineage. The lineage data comprises the TaxIds, scientific names, and ranks of its parent taxa.
 
 ```pycon
 >>> print(lagomorpha.taxid)
@@ -80,6 +80,8 @@ Each [`Taxon`][taxopy.Taxon] object stores various data related to the taxon, in
 [('order', 9975), ('clade', 314147), ('superorder', 314146), ('clade', 1437010), ('clade', 9347), ('clade', 32525), ('class', 40674), ('clade', 32524), ('clade', 32523), ('clade', 1338369), ('superclass', 8287), ('clade', 117571), ('clade', 117570), ('clade', 7776), ('clade', 7742), ('subphylum', 89593), ('phylum', 7711), ('clade', 33511), ('clade', 33213), ('clade', 6072), ('kingdom', 33208), ('clade', 33154), ('superkingdom', 2759), ('no rank', 131567), ('no rank', 1)]
 >>> print(lagomorpha.name)
 Lagomorpha
+>>> print(lagomorpha.all_names)
+{'authority': ['Lagomorpha Brandt, 1855'], 'scientific name': ['Lagomorpha'], 'blast name': ['rabbits & hares']}
 >>> print(lagomorpha.name_lineage)
 ['Lagomorpha', 'Glires', 'Euarchontoglires', 'Boreoeutheria', 'Eutheria', 'Theria', 'Mammalia', 'Amniota', 'Tetrapoda', 'Dipnotetrapodomorpha', 'Sarcopterygii', 'Euteleostomi', 'Teleostomi', 'Gnathostomata', 'Vertebrata', 'Craniata', 'Chordata', 'Deuterostomia', 'Bilateria', 'Eumetazoa', 'Metazoa', 'Opisthokonta', 'Eukaryota', 'cellular organisms', 'root']
 >>> print(lagomorpha.ranked_name_lineage)
@@ -88,6 +90,18 @@ Lagomorpha
 OrderedDict({'order': 'Lagomorpha', 'clade': 'Opisthokonta', 'superorder': 'Euarchontoglires', 'class': 'Mammalia', 'superclass': 'Sarcopterygii', 'subphylum': 'Craniata', 'phylum': 'Chordata', 'kingdom': 'Metazoa', 'superkingdom': 'Eukaryota'})
 >>> print(lagomorpha.rank)
 order
+```
+
+A taxon's scientific name is stored in the `name` field, while `all_names` is a dictionary from the kind of name to a list of names. 
+
+```pycon
+>>> sus = taxopy.Taxon(9823, taxdb)
+>>> print(sus.name)
+'Sus scrofa'
+>>> print(sus.all_names)
+{'genbank common name': ['pig'], 'common name': ['pigs', 'swine', 'wild boar'], 'authority': ['Sus scrofa Linnaeus, 1758'], 'includes': ['Sus scrofa LW', 'Sus scrofa Pietrain'], 'scientific name': ['Sus scrofa']}
+>>> print(sus.all_names['common name'])
+['pigs', 'swine', 'wild boar']
 ```
 
 To obtain the [`Taxon`][taxopy.Taxon] object for the parent of a specified taxon, you can use the `parent` method.

--- a/taxopy/core.py
+++ b/taxopy/core.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import os
 import tarfile
 import urllib.request
-from collections import OrderedDict, defaultdict
+from collections import OrderedDict
 from typing import Dict, List, Tuple, Optional
 
 from taxopy.exceptions import DownloadError, ExtractionError, TaxidError
@@ -246,10 +246,10 @@ class TaxDb:
 
                 taxid2all_names[taxid][kind].append(name)
 
-            if self._merged_dmp:
-                for oldtaxid, newtaxid in self._oldtaxid2newtaxid.items():
-                    taxid2name[oldtaxid] = taxid2name[newtaxid]
-                    taxid2all_names[oldtaxid] = taxid2all_names[newtaxid]
+        if self._merged_dmp:
+            for oldtaxid, newtaxid in self._oldtaxid2newtaxid.items():
+                taxid2name[oldtaxid] = taxid2name[newtaxid]
+                taxid2all_names[oldtaxid] = taxid2all_names[newtaxid]
 
         return taxid2name, taxid2all_names
 

--- a/taxopy/core.py
+++ b/taxopy/core.py
@@ -137,7 +137,7 @@ class TaxDb:
         return self._taxid2name
 
     @property
-    def taxid2names(self) -> Dict[int, str]:
+    def taxid2names(self) -> Dict[int, List[Tuple[str, str]]]:
         return self._taxid2names
 
     @property
@@ -340,7 +340,7 @@ class Taxon:
         return self._name
 
     @property
-    def names(self) -> str:
+    def names(self) -> List[Tuple[str, str]]:
         return self._names
 
     @property


### PR DESCRIPTION
Hi Antonio, not sure if you will find this useful, but I needed a more complete list of names for a taxon in addition to the scientific name. I didn't update the docs yet. If you'd consider merging this, I can also add something to the documentation.

```
(Pdb) taxopy.Taxon(9606, ncbi_taxonomy).name
'Homo sapiens'

(Pdb) taxopy.Taxon(9606, ncbi_taxonomy).names
[('authority', 'Homo sapiens Linnaeus, 1758'), ('scientific name', 'Homo sapiens'), ('genbank common name', 'human')]

(Pdb) taxopy.Taxon(10090, ncbi_taxonomy).names
[('genbank common name', 'house mouse'), ('includes', 'LK3 transgenic mice'), ('common name', 'mouse'), ('authority', 'Mus musculus Linnaeus, 1758'), ('scientific name', 'Mus musculus'), ('includes', 'Mus sp. 129SV'), ('includes', 'nude mice'), ('includes', 'transgenic mice')]

(Pdb) taxopy.Taxon(9823, ncbi_taxonomy).names
[('genbank common name', 'pig'), ('common name', 'pigs'), ('authority', 'Sus scrofa Linnaeus, 1758'), ('scientific name', 'Sus scrofa'), ('common name', 'swine'), ('common name', 'wild boar')]

```

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduce a new feature to the `Taxon` class that allows retrieval of a comprehensive list of names for a taxon, enhancing the existing functionality by including various name types such as scientific, common, and authority names.

New Features:
- Add a new property `names` to the `Taxon` class that provides a list of all names associated with a taxon, including scientific, common, and authority names.

Enhancements:
- Extend the `_import_names` method to populate a new dictionary `taxid2names` that stores all names associated with each taxon ID.

<!-- Generated by sourcery-ai[bot]: end summary -->