### PR TITLE
Add JOSS paper for Taxopy package with tests and GitHub Actions

### DIFF
--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -1,0 +1,28 @@
+name: Draft PDF
+on:
+  push:
+    paths:
+      - paper/**
+      - .github/workflows/draft-pdf.yml
+
+jobs:
+  paper:
+    runs-on: ubuntu-latest
+    name: Paper Draft
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build draft PDF
+        uses: openjournals/openjournals-draft-action@master
+        with:
+          journal: joss
+          # This should be the path to the paper within your repo.
+          paper-path: paper.md
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: paper
+          # This is the output path where Pandoc will write the compiled
+          # PDF. Note, this should be the same directory as the input
+          # paper.md
+          path: paper.pdf

--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           journal: joss
           # This should be the path to the paper within your repo.
-          paper-path: paper.md
+          paper-path: paper/paper.md
       - name: Upload
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -25,4 +25,4 @@ jobs:
           # This is the output path where Pandoc will write the compiled
           # PDF. Note, this should be the same directory as the input
           # paper.md
-          path: paper.pdf
+          path: paper/paper.pdf

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Installation
 
-There are two ways to install `taxopy`:
+There are several ways to install `taxopy`:
 
   - Using pip:
 
@@ -16,10 +16,34 @@ There are two ways to install `taxopy`:
 pip install taxopy
 ```
 
+  - Using uv:
+
+```
+uv init example
+cd example
+uv add taxopy
+```
+
   - Using conda:
 
 ```
-conda install -c conda-forge -c bioconda taxopy
+conda create -n taxopy-env -c conda-forge -c bioconda taxopy
+conda activate taxopy-env
+```
+
+  - Using pixi:
+
+```
+pixi init --channel conda-forge --channel bioconda example
+cd example
+pixi add taxopy
+```
+
+  - Using mamba:
+
+```
+mamba create -n taxopy-env -c conda-forge -c bioconda taxopy
+mamba activate taxopy-env
 ```
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -219,6 +219,20 @@ for t in taxopy.taxid_from_name(
     Myxococcota
     Myxococcaceae
 
+## Running tests
+
+Install the test dependencies and run the default test suite with `uv`:
+
+```bash
+uv run --extra test pytest
+```
+
+The repository also includes integration tests that download the taxonomy dump through `taxopy` itself. These tests are skipped by default because they require network access and depend on the current NCBI taxonomy data. Run them explicitly with:
+
+```bash
+uv run --extra test pytest --run-network
+```
+
 ## Acknowledgements
 
 Some of the code used in taxopy was taken from the [CAT/BAT tool for taxonomic classification of contigs and metagenome-assembled genomes](https://github.com/dutilh/CAT).

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -71,3 +71,77 @@
 	url = {http://dx.doi.org/10.1093/molbev/msw046},
 	langid = {en}
 }
+
+@article{camargo2023,
+	title = {Identification of mobile genetic elements with geNomad},
+	author = {Camargo, Antonio Pedro and Roux, Simon and Schulz, Frederik and Babinski, Michal and Xu, Yan and Hu, Bin and Chain, Patrick S. G. and Nayfach, Stephen and Kyrpides, Nikos C.},
+	year = {2023},
+	month = {09},
+	date = {2023-09-21},
+	journal = {Nature Biotechnology},
+	pages = {1303--1312},
+	volume = {42},
+	number = {8},
+	doi = {10.1038/s41587-023-01953-y},
+	url = {http://dx.doi.org/10.1038/s41587-023-01953-y},
+	langid = {en}
+}
+
+@article{fiamenghi2025,
+	title = {Meta-virus resource (MetaVR): expanding the frontiers of viral diversity with 24 million uncultivated virus genomes},
+	author = {Fiamenghi, Mateus B and Camargo, Antonio Pedro and Chasapi, Iro N and Baltoumas, Fotis A and Roux, Simon and Egorov, Artyom A and Aplakidou, Eleni and Ndela, Eric Olo and Vasquez, Yumary M and Chen, I-Min A and Palaniappan, Krishna and Reddy, T B K and Mukherjee, Supratim and Ivanova, Natalia N and Schulz, Frederik and Woyke, Tanja and Eloe-Fadrosh, Emiley A and Pavlopoulos, Georgios A and Kyrpides, Nikos C},
+	year = {2025},
+	month = {11},
+	date = {2025-11-28},
+	journal = {Nucleic Acids Research},
+	pages = {D801--D812},
+	volume = {54},
+	number = {D1},
+	doi = {10.1093/nar/gkaf1283},
+	url = {http://dx.doi.org/10.1093/nar/gkaf1283},
+	langid = {en}
+}
+
+@article{fiamenghi2025a,
+	title = {A global soil plasmidome resource unveils functional and ecological roles of plasmids in soil microbiomes},
+	author = {Fiamenghi, Mateus B. and Camargo, Antonio Pedro and Ivanova, Natalia N. and Graham, Emily B. and Wu, Ruonan and Hofmockel, Kirsten S. and Kyrpides, Nikos C.},
+	year = {2025},
+	month = {11},
+	date = {2025-11-18},
+	journal = {Nature Communications},
+	volume = {16},
+	number = {1},
+	doi = {10.1038/s41467-025-65102-6},
+	url = {http://dx.doi.org/10.1038/s41467-025-65102-6},
+	langid = {en}
+}
+
+@article{shen2021a,
+	title = {TaxonKit: A practical and efficient NCBI taxonomy toolkit},
+	author = {Shen, Wei and Ren, Hong},
+	year = {2021},
+	month = {09},
+	date = {2021-09},
+	journal = {Journal of Genetics and Genomics},
+	pages = {844--850},
+	volume = {48},
+	number = {9},
+	doi = {10.1016/j.jgg.2021.03.006},
+	url = {http://dx.doi.org/10.1016/j.jgg.2021.03.006},
+	langid = {en}
+}
+
+@article{dobzhansky1964,
+	title = {BIOLOGY, MOLECULAR AND ORGANISMIC},
+	author = {DOBZHANSKY, THEODOSIUS},
+	year = {1964},
+	month = {11},
+	date = {1964-11},
+	journal = {American Zoologist},
+	pages = {443--452},
+	volume = {4},
+	number = {4},
+	doi = {10.1093/icb/4.4.443},
+	url = {http://dx.doi.org/10.1093/icb/4.4.443},
+	langid = {en}
+}

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -145,3 +145,33 @@
 	url = {http://dx.doi.org/10.1093/icb/4.4.443},
 	langid = {en}
 }
+
+@article{yang2002,
+	title = {Codon-Substitution Models for Detecting Molecular Adaptation at Individual Sites Along Specific Lineages},
+	author = {Yang, Ziheng and Nielsen, Rasmus},
+	year = {2002},
+	month = {06},
+	date = {2002-06-01},
+	journal = {Molecular Biology and Evolution},
+	pages = {908--917},
+	volume = {19},
+	number = {6},
+	doi = {10.1093/oxfordjournals.molbev.a004148},
+	url = {http://dx.doi.org/10.1093/oxfordjournals.molbev.a004148},
+	langid = {en}
+}
+
+@article{massingham2005,
+	title = {Detecting Amino Acid Sites Under Positive Selection and Purifying Selection},
+	author = {Massingham, Tim and Goldman, Nick},
+	year = {2005},
+	month = {03},
+	date = {2005-03-01},
+	journal = {Genetics},
+	pages = {1753--1762},
+	volume = {169},
+	number = {3},
+	doi = {10.1534/genetics.104.032144},
+	url = {http://dx.doi.org/10.1534/genetics.104.032144},
+	langid = {en}
+}

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -1,0 +1,28 @@
+
+@article{schoch2020,
+	title = {NCBI Taxonomy: a comprehensive update on curation, resources and tools},
+	author = {Schoch, Conrad L and Ciufo, Stacy and Domrachev, Mikhail and Hotton, Carol L and Kannan, Sivakumar and Khovanskaya, Rogneda and Leipe, Detlef and Mcveigh, Richard and {O{\textquoteright}Neill}, Kathleen and Robbertse, Barbara and Sharma, Shobha and Soussov, Vladimir and Sullivan, John P and Sun, Lu and Turner, {Seán} and Karsch-Mizrachi, Ilene},
+	year = {2020},
+	month = {01},
+	date = {2020-01-01},
+	journal = {Database},
+	volume = {2020},
+	doi = {10.1093/database/baaa062},
+	url = {http://dx.doi.org/10.1093/database/baaa062},
+	langid = {en}
+}
+
+@article{parks2025,
+	title = {GTDB release 10: a complete and systematic taxonomy for 715 230 bacterial and 17 245 archaeal genomes},
+	author = {Parks, Donovan H and Chaumeil, Pierre-Alain and Mussig, Aaron J and Rinke, Christian and Chuvochina, Maria and Hugenholtz, Philip},
+	year = {2025},
+	month = {10},
+	date = {2025-10-22},
+	journal = {Nucleic Acids Research},
+	pages = {D743--D754},
+	volume = {54},
+	number = {D1},
+	doi = {10.1093/nar/gkaf1040},
+	url = {http://dx.doi.org/10.1093/nar/gkaf1040},
+	langid = {en}
+}

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -26,3 +26,48 @@
 	url = {http://dx.doi.org/10.1093/nar/gkaf1040},
 	langid = {en}
 }
+
+@article{shen2021,
+	title = {TaxonKit: A practical and efficient NCBI taxonomy toolkit},
+	author = {Shen, Wei and Ren, Hong},
+	year = {2021},
+	month = {09},
+	date = {2021-09},
+	journal = {Journal of Genetics and Genomics},
+	pages = {844--850},
+	volume = {48},
+	number = {9},
+	doi = {10.1016/j.jgg.2021.03.006},
+	url = {http://dx.doi.org/10.1016/j.jgg.2021.03.006},
+	langid = {en}
+}
+
+@article{mcdonald2023,
+	title = {Greengenes2 unifies microbial data in a single reference tree},
+	author = {McDonald, Daniel and Jiang, Yueyu and Balaban, Metin and Cantrell, Kalen and Zhu, Qiyun and Gonzalez, Antonio and Morton, James T. and Nicolaou, Giorgia and Parks, Donovan H. and Karst, {Søren M.} and Albertsen, Mads and Hugenholtz, Philip and DeSantis, Todd and Song, Se Jin and Bartko, Andrew and Havulinna, Aki S. and Jousilahti, Pekka and Cheng, Susan and Inouye, Michael and Niiranen, Teemu and Jain, Mohit and Salomaa, Veikko and Lahti, Leo and Mirarab, Siavash and Knight, Rob},
+	year = {2023},
+	month = {07},
+	date = {2023-07-27},
+	journal = {Nature Biotechnology},
+	pages = {715--718},
+	volume = {42},
+	number = {5},
+	doi = {10.1038/s41587-023-01845-1},
+	url = {http://dx.doi.org/10.1038/s41587-023-01845-1},
+	langid = {en}
+}
+
+@article{huerta-cepas2016,
+	title = {ETE 3: Reconstruction, Analysis, and Visualization of Phylogenomic Data},
+	author = {Huerta-Cepas, Jaime and Serra, {François} and Bork, Peer},
+	year = {2016},
+	month = {02},
+	date = {2016-02-26},
+	journal = {Molecular Biology and Evolution},
+	pages = {1635--1638},
+	volume = {33},
+	number = {6},
+	doi = {10.1093/molbev/msw046},
+	url = {http://dx.doi.org/10.1093/molbev/msw046},
+	langid = {en}
+}

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -1,0 +1,37 @@
+---
+title: 'Taxopy: A Python package for obtaining complete lineages and the lowest common ancestor (LCA) from a set of taxonomic identifiers'
+tags:
+  - Python
+  - biology
+  - evolution
+  - computational mechanics
+
+authors:
+  - name: Antonio Pedro Camargo
+    orcid: 0000-0003-3913-2484
+    affiliation: "1, 2"
+    corresponding: true
+  - name: Mateus B. Fiamenghi
+    orcid: 0000-0003-4535-8594
+    affiliation: 1
+    corresponding: true
+affiliations:
+ - name: DOE Joint Genome Institute, Lawrence Berkeley National Laboratory, Berkeley, United States
+   index: 1
+ - name: Department of Biochemistry, Institute of Chemistry, University of São Paulo, São Paulo, Brazil
+   index: 2
+date: 26 February 2026
+bibliography: references.bib
+
+---
+
+# Summary
+[Taxopy](https://github.com/apcamargo/taxopy) summary
+
+# Statement of need
+
+# Acknowledgements
+A.P.C wrote the software and revised the manuscript
+M.B.F revised the software and wrote the manuscript
+
+# References

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -4,7 +4,7 @@ tags:
   - python
   - biology
   - evolution
-  - computational mechanics
+  - bioinformatics
 
 authors:
   - name: Antonio Pedro Camargo
@@ -26,7 +26,7 @@ bibliography: paper.bib
 
 # Summary
 
-Dobzhansky once famously said, "Nothing in biology makes sense except in the light of evolution". Indeed, without an evolutionary perspective, hypothesis testing of biological systems would be severely limited to simple data analysis. This is especially true in the age of big data, where large datasets of genomic, transcriptomic, and proteomic information are being generated at an unprecedented rate.
+Dobzhansky once famously said, "Nothing in biology makes sense except in the light of evolution" [@dobzhansky1964]. Indeed, without an evolutionary perspective, hypothesis testing of biological systems would be severely limited to simple data analysis. This is especially true in the age of big data, where large datasets of genomic, transcriptomic, and proteomic information are being generated at an unprecedented rate.
 
 `Taxopy` is a Python package that provides an accessible programmatic interface for navigating these complex evolutionary relationships. It allows researchers to seamlessly convert basic taxonomic identifiers into complete evolutionary lineages, find the lowest common ancestor (LCA) among groups of organisms, and translate between different taxonomic databases. By handling the heavy lifting of taxonomic data parsing, `Taxopy` enables biologists and bioinformaticians to easily integrate evolutionary context into their data analysis workflows.
 
@@ -40,7 +40,7 @@ To map taxonomic lineages to numeric identifiers and compute relationships betwe
 
 # State of the field
 
-Several tools currently exist to facilitate taxonomic data manipulation, such as the `ETE toolkit` [@huerta-cepas2016], `taxize` and `Taxonkit` [@shen2021]. Below we list the main attributes of each of these programs:
+Several tools currently exist to facilitate taxonomic data manipulation, such as the `ETE toolkit` [@huerta-cepas2016], [`taxize`](https://github.com/ropensci/taxize) and `Taxonkit` [@shen2021]. Below we list the main attributes of each of these programs:
 
 - `ETE toolkit`: a python package mostly tailored for manipulating phylogenies and hypothesis testing via integration with the PAML suite, but also includes some taxonomy parsing helpers.
 
@@ -60,7 +60,7 @@ To ensure broad compatibility and minimize dependencies, `Taxopy` is designed as
 
 # Research impact statement
 
-`Taxopy` has seen positive reception and adoption within the bioinformatics community. Since its release, the package has accrued over 59,000 downloads on Bioconda, garnered more than 50 GitHub stars, and generated several forks, demonstrating its active use in the open-source ecosystem. Furthermore, it has been cited in several preprints and peer-reviewed publications, confirming its utility in active research.
+`Taxopy` has seen positive reception and adoption within the scientific community. Since its release, the package has accrued over 59 thousand downloads on Bioconda, has more than 50 GitHub stars, and generated several forks, demonstrating its active use in the open-source ecosystem. Furthermore, it has been cited in several peer-reviewed publications [@camargo2023; @fiamenghi2025; @fiamenghi2025a; @shen2021a], confirming its utility in active research.
 
 # AI usage disclosure
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -1,7 +1,7 @@
 ---
-title: "Taxopy: A Python package for obtaining complete lineages and the lowest common ancestor (LCA) from a set of taxonomic identifiers"
+title: "`Taxopy`: A Python package for obtaining complete lineages and the lowest common ancestor (LCA) from a set of taxonomic identifiers"
 tags:
-  - Python
+  - python
   - biology
   - evolution
   - computational mechanics
@@ -26,36 +26,50 @@ bibliography: paper.bib
 
 # Summary
 
-A description of the high-level functionality and purpose of the software for a diverse, non-specialist audience.
+Dobzhansky once famously said, "Nothing in biology makes sense except in the light of evolution". Indeed, without an evolutionary perspective, hypothesis testing of biological systems would be severely limited to simple data analysis. This is especially true in the age of big data, where large datasets of genomic, transcriptomic, and proteomic information are being generated at an unprecedented rate.
 
-Dobzhansky once famously said, "Nothing in biology makes sense except in the light of evolution". Indeed, without an evolutionary perspective, hypothesis testing of biological systems would be severely limited into simple data analysis. This is especially true in the age of big data, where large datasets of genomic, transcriptomic, and proteomic information are being generated at an unprecedented rate.
-
-Taxonomic classifications provide a framework for organizing this diversity and allow comparative evolutionary studies across different species. However, obtaining complete lineages and the lowest common ancestor (LCA) from a set of taxonomic identifiers has been historically a complex task, especially when dealing with large datasets. Furthermore, there are different standards for taxonomic classification, such as NCBI taxonomy [@schoch2020] and GTDB [@parks2025](for prokaryotes), which can lead to inconsistencies and difficulties in data integration.
-
-Here we present [Taxopy](https://github.com/apcamargo/taxopy), a Python package designed to simplify the process of obtaining taxonomic ranks and lineages by providing an easy-to-use interface for retrieving information from various databases. Taxopy allows users to obtain complete lineages by mapping against taxdump files (a format implemented by several taxonomic databases) either through a numeric identifier or by using the taxa name. Furthermore, the package contains helper functions to retrieve the LCA from a list of taxonomic identifiers, as well as compute the majority vote when comparing between taxa where a subset is more distantly related. Taxopy is particularly useful for researchers working with large datasets, as it streamlines the process of taxonomic classification and facilitates comparative evolutionary analyses.
+`Taxopy` is a Python package that provides an accessible programmatic interface for navigating these complex evolutionary relationships. It allows researchers to seamlessly convert basic taxonomic identifiers into complete evolutionary lineages, find the lowest common ancestor (LCA) among groups of organisms, and translate between different taxonomic databases. By handling the heavy lifting of taxonomic data parsing, `Taxopy` enables biologists and bioinformaticians to easily integrate evolutionary context into their data analysis workflows.
 
 # Statement of need
 
-A section that clearly illustrates the research purpose of the software and places it in the context of related work. This should clearly state what problems the software is designed to solve, who the target audience is, and its relation to other work.
+Obtaining complete lineages and the lowest common ancestor (LCA) from a set of taxonomic identifiers has historically been a complex task, especially when dealing with large datasets. Furthermore, differing standards for taxonomic classification, such as the National Center for Biotechnology Information (NCBI) taxonomy [@schoch2020] and the Genome Taxonomy Database GTDB [@parks2025] for prokaryotes, often lead to inconsistencies and difficulties in data integration.
+
+To map taxonomic lineages to numeric identifiers and compute relationships between organisms, several bioinformatics tools utilize "taxdumps", a file format pioneered by NCBI. However, parsing and utilizing these taxdump files outside of specialized programs is non-trivial.
+
+`Taxopy` is a python package designed to simplify the retrieval of taxonomic ranks and lineages for researchers from any biological field, by allowing users to obtain complete lineages by mapping numeric identifiers or taxa names directly against taxdump files. Furthermore, the package contains helper functions to retrieve the LCA from a list of taxonomic identifiers, as well as to compute a majority-vote consensus when comparing taxa where a subset is more distantly related. `Taxopy` is particularly useful for researchers working with large datasets, as it streamlines taxonomic classification and facilitates comparative evolutionary analyses.
 
 # State of the field
 
-A description of how this software compares to other commonly-used packages in the research area. If related tools exist, provide a clear “build vs. contribute” justification explaining your unique scholarly contribution and why existing alternatives are insufficient.
+Several tools currently exist to facilitate taxonomic data manipulation, such as the `ETE toolkit` [@huerta-cepas2016], `taxize` and `Taxonkit` [@shen2021]. Below we list the main attributes of each of these programs:
+
+- `ETE toolkit`: a python package mostly tailored for manipulating phylogenies and hypothesis testing via integration with the PAML suite, but also includes some taxonomy parsing helpers.
+
+- `taxize`: an R package that maps taxonomic data via web APIs across many sources, and does not rely on taxdump files.
+
+- `Taxonkit`: a CLI tool designed for high-throughput shell manipulation of taxonomic data, capable of creating novel taxdump files.
+
+While these tools offer overlapping functionalities, such as programmatic access to hierarchical taxonomy operations, identifier resolution, and LCA computation, `Taxopy` is uniquely positioned in the ecosystem. First, it is designed to be integrated into custom python workflows, or used as a lightweight dependency for other python libraries leveraging its low-level functions. Second, `Taxopy` provides specialized functions to calculate the majority vote between distantly related taxa when a LCA would be too broad, and handle inconsistencies between different taxonomic database by converting names between different taxdumps.
 
 # Software design
 
-An explanation of the trade-offs you weighed, the design/architecture you chose, and why it matters for your research application. This should demonstrate meaningful design thinking beyond a superficial code structure description.
+The core design of `Taxopy` is around the `Taxon` object, from which all taxonomic attributes stem. To initialize a `Taxon`, a taxdump file is required. `Taxopy` enables users to easily download or pass a taxdump through the flexible `TaxDb` object, which then eagerly parses the taxdump into python dictionaries to allow for rapid, in-memory searches.
+
+Once a `Taxon` object is initialized, users can explore different lineage attributes, including the hierarchical organization (which allows retrieving the parent lineage), alternative taxa names, and the full lineage (including sublineages). The API provides users the flexibility to format the returned objects as needed; for instance, leveraging the `Taxon.rank_name_dictionary` method to generate a Greengenes-formatted string [@mcdonald2023], a standard widely used for taxonomic representation in microbiome research.
+
+To ensure broad compatibility and minimize dependencies, `Taxopy` is designed as a mostly pure-Python package. It relies only on `flit_core` for PyPI deployment, `pytest` for testing, and the optional `rapidfuzz` dependency to enable fuzzy searching of partial name matches via the `taxid_from_name` utility function. Consequently, the internal objects are implemented using native Python dictionaries and standard library data structures, ensuring a lightweight footprint and fast execution times.
 
 # Research impact statement
 
-Evidence of realized impact (publications, external use, integrations) or credible near-term significance (benchmarks, reproducible materials, community-readiness signals). The evidence should be compelling and specific, not aspirational.
+`Taxopy` has seen positive reception and adoption within the bioinformatics community. Since its release, the package has accrued over 59,000 downloads on Bioconda, garnered more than 50 GitHub stars, and generated several forks, demonstrating its active use in the open-source ecosystem. Furthermore, it has been cited in several preprints and peer-reviewed publications, confirming its utility in active research.
 
 # AI usage disclosure
 
-Transparent disclosure of any use of generative AI in the software creation, documentation, or paper authoring. If no AI tools were used, state this explicitly. If AI tools were used, describe how they were used and how the quality and correctness of AI-generated content was verified.
+Generative AI (Codex) was used to aid in writing comprehensive unit tests for the software; all generated code was manually reviewed and revised by the authors for soundness. Google Gemini was used for grammar correction and structural editing of this manuscript.
 
 # Acknowledgements
 
-A.P.C wrote the software and revised the manuscript M.B.F revised the software and wrote the manuscript
+A.P.C wrote the software and revised the manuscript
+
+M.B.F revised the software and wrote the manuscript
 
 # References

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -1,5 +1,5 @@
 ---
-title: 'Taxopy: A Python package for obtaining complete lineages and the lowest common ancestor (LCA) from a set of taxonomic identifiers'
+title: "Taxopy: A Python package for obtaining complete lineages and the lowest common ancestor (LCA) from a set of taxonomic identifiers"
 tags:
   - Python
   - biology
@@ -16,21 +16,26 @@ authors:
     affiliation: 1
     corresponding: true
 affiliations:
- - name: DOE Joint Genome Institute, Lawrence Berkeley National Laboratory, Berkeley, United States
-   index: 1
- - name: Department of Biochemistry, Institute of Chemistry, University of São Paulo, São Paulo, Brazil
-   index: 2
+  - name: DOE Joint Genome Institute, Lawrence Berkeley National Laboratory, Berkeley, United States
+    index: 1
+  - name: Department of Biochemistry, Institute of Chemistry, University of São Paulo, São Paulo, Brazil
+    index: 2
 date: 26 February 2026
 bibliography: references.bib
-
 ---
 
 # Summary
-[Taxopy](https://github.com/apcamargo/taxopy) summary
+
+Dobzhansky once famously said, "Nothing in biology makes sense except in the light of evolution". Indeed, without an evolutionary perspective, hypothesis testing of biological systems would be severely limited into simple data analysis. This is especially true in the age of big data, where large datasets of genomic, transcriptomic, and proteomic information are being generated at an unprecedented rate.
+
+Taxonomic classifications provide a framework for organizing this diversity and allow comparative evolutionary studies across different species. However, obtaining complete lineages and the lowest common ancestor (LCA) from a set of taxonomic identifiers has been historically a complex task, especially when dealing with large datasets. Furthermore, there are different standards for taxonomic classification, such as NCBI taxonomy and GTDB (for prokaryotes), which can lead to inconsistencies and difficulties in data integration.
+
+Here we present Taxopy [Taxopy](https://github.com/apcamargo/taxopy), a Python package designed to simplify the process of obtaining taxonomic ranks and lineages by providing an easy-to-use interface for retrieving information from various databases. Taxopy allows users to obtain complete lineages by mapping against taxdump files, a format implemented by several taxonomic databases, either through a numeric identifier, or by using the taxa name. Furthermore, the package contains helper functions to retrieve the LCA from a list of taxonomic identifiers, as well as compute the majority vote when comparing between taxa where a subset is more distantly related. Taxopy is particularly useful for researchers working with large datasets, as it streamlines the process of taxonomic classification and facilitates comparative evolutionary analyses.
 
 # Statement of need
 
 # Acknowledgements
+
 A.P.C wrote the software and revised the manuscript
 M.B.F revised the software and wrote the manuscript
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -21,22 +21,41 @@ affiliations:
   - name: Department of Biochemistry, Institute of Chemistry, University of São Paulo, São Paulo, Brazil
     index: 2
 date: 26 February 2026
-bibliography: references.bib
+bibliography: paper.bib
 ---
 
 # Summary
 
+A description of the high-level functionality and purpose of the software for a diverse, non-specialist audience.
+
 Dobzhansky once famously said, "Nothing in biology makes sense except in the light of evolution". Indeed, without an evolutionary perspective, hypothesis testing of biological systems would be severely limited into simple data analysis. This is especially true in the age of big data, where large datasets of genomic, transcriptomic, and proteomic information are being generated at an unprecedented rate.
 
-Taxonomic classifications provide a framework for organizing this diversity and allow comparative evolutionary studies across different species. However, obtaining complete lineages and the lowest common ancestor (LCA) from a set of taxonomic identifiers has been historically a complex task, especially when dealing with large datasets. Furthermore, there are different standards for taxonomic classification, such as NCBI taxonomy and GTDB (for prokaryotes), which can lead to inconsistencies and difficulties in data integration.
+Taxonomic classifications provide a framework for organizing this diversity and allow comparative evolutionary studies across different species. However, obtaining complete lineages and the lowest common ancestor (LCA) from a set of taxonomic identifiers has been historically a complex task, especially when dealing with large datasets. Furthermore, there are different standards for taxonomic classification, such as NCBI taxonomy [@schoch2020] and GTDB [@parks2025](for prokaryotes), which can lead to inconsistencies and difficulties in data integration.
 
-Here we present Taxopy [Taxopy](https://github.com/apcamargo/taxopy), a Python package designed to simplify the process of obtaining taxonomic ranks and lineages by providing an easy-to-use interface for retrieving information from various databases. Taxopy allows users to obtain complete lineages by mapping against taxdump files, a format implemented by several taxonomic databases, either through a numeric identifier, or by using the taxa name. Furthermore, the package contains helper functions to retrieve the LCA from a list of taxonomic identifiers, as well as compute the majority vote when comparing between taxa where a subset is more distantly related. Taxopy is particularly useful for researchers working with large datasets, as it streamlines the process of taxonomic classification and facilitates comparative evolutionary analyses.
+Here we present [Taxopy](https://github.com/apcamargo/taxopy), a Python package designed to simplify the process of obtaining taxonomic ranks and lineages by providing an easy-to-use interface for retrieving information from various databases. Taxopy allows users to obtain complete lineages by mapping against taxdump files (a format implemented by several taxonomic databases) either through a numeric identifier or by using the taxa name. Furthermore, the package contains helper functions to retrieve the LCA from a list of taxonomic identifiers, as well as compute the majority vote when comparing between taxa where a subset is more distantly related. Taxopy is particularly useful for researchers working with large datasets, as it streamlines the process of taxonomic classification and facilitates comparative evolutionary analyses.
 
 # Statement of need
 
+A section that clearly illustrates the research purpose of the software and places it in the context of related work. This should clearly state what problems the software is designed to solve, who the target audience is, and its relation to other work.
+
+# State of the field
+
+A description of how this software compares to other commonly-used packages in the research area. If related tools exist, provide a clear “build vs. contribute” justification explaining your unique scholarly contribution and why existing alternatives are insufficient.
+
+# Software design
+
+An explanation of the trade-offs you weighed, the design/architecture you chose, and why it matters for your research application. This should demonstrate meaningful design thinking beyond a superficial code structure description.
+
+# Research impact statement
+
+Evidence of realized impact (publications, external use, integrations) or credible near-term significance (benchmarks, reproducible materials, community-readiness signals). The evidence should be compelling and specific, not aspirational.
+
+# AI usage disclosure
+
+Transparent disclosure of any use of generative AI in the software creation, documentation, or paper authoring. If no AI tools were used, state this explicitly. If AI tools were used, describe how they were used and how the quality and correctness of AI-generated content was verified.
+
 # Acknowledgements
 
-A.P.C wrote the software and revised the manuscript
-M.B.F revised the software and wrote the manuscript
+A.P.C wrote the software and revised the manuscript M.B.F revised the software and wrote the manuscript
 
 # References

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -42,7 +42,7 @@ To map taxonomic lineages to numeric identifiers and compute relationships betwe
 
 Several tools currently exist to facilitate taxonomic data manipulation, such as the `ETE toolkit` [@huerta-cepas2016], [`taxize`](https://github.com/ropensci/taxize) and `Taxonkit` [@shen2021]. Below we list the main attributes of each of these programs:
 
-- `ETE toolkit`: a python package mostly tailored for manipulating phylogenies and hypothesis testing via integration with the PAML suite, but also includes some taxonomy parsing helpers.
+- `ETE toolkit`: a python package mostly tailored for manipulating phylogenies and hypothesis testing via CodeML [@yang2002] and Slr [@massingham2005], but also includes some taxonomy parsing helpers.
 
 - `taxize`: an R package that maps taxonomic data via web APIs across many sources, and does not rely on taxdump files.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,11 @@ classifiers = [
 
 [project.optional-dependencies]
 fuzzy-matching = ["rapidfuzz"]
+test = ["pytest>=7,<9; python_version >= '3.8'"]
 
 [project.urls]
 Documentation = "https://apcamargo.github.io/taxopy"
 Repository = "https://github.com/apcamargo/taxopy"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,55 @@
+import os
+import shutil
+
+import pytest
+
+import taxopy
+
+NCBI_TAXDUMP_URL = "https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz"
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--run-network",
+        action="store_true",
+        default=False,
+        help="run tests that download the NCBI taxonomy dump",
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "network: requires downloading the NCBI taxonomy dump",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--run-network"):
+        return
+
+    skip_network = pytest.mark.skip(
+        reason="requires network access; run pytest with --run-network",
+    )
+    for item in items:
+        if "network" in item.keywords:
+            item.add_marker(skip_network)
+
+
+@pytest.fixture(scope="session")
+def ncbi_taxdb(tmp_path_factory):
+    taxdb_dir = tmp_path_factory.mktemp("taxdb")
+    taxdump_url = os.environ.get("TAXOPY_TEST_TAXDUMP_URL", NCBI_TAXDUMP_URL)
+
+    try:
+        taxdb = taxopy.TaxDb(
+            taxdb_dir=str(taxdb_dir),
+            taxdump_url=taxdump_url,
+        )
+    except Exception:
+        shutil.rmtree(taxdb_dir, ignore_errors=True)
+        raise
+
+    yield taxdb
+
+    shutil.rmtree(taxdb_dir, ignore_errors=True)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,45 @@
+import pytest
+
+import taxopy
+from taxopy.exceptions import TaxidError
+
+
+@pytest.mark.network
+def test_taxdb_loads_known_taxonomy_records(ncbi_taxdb):
+    assert ncbi_taxdb.taxid2name[9606] == "Homo sapiens"
+    assert ncbi_taxdb.taxid2parent[9606] == 9605
+    assert ncbi_taxdb.taxid2rank[9606] == "species"
+    assert ncbi_taxdb.taxid2all_names[9606]["scientific name"] == ["Homo sapiens"]
+
+
+@pytest.mark.network
+def test_taxon_exposes_lineage_rank_lookup_and_parent(ncbi_taxdb):
+    human = taxopy.Taxon(9606, ncbi_taxdb)
+
+    assert human.name == "Homo sapiens"
+    assert human.rank == "species"
+    assert human.legacy_taxid is False
+    assert human.name_lineage[:3] == ["Homo sapiens", "Homo", "Homininae"]
+    assert human.rank_name_dictionary["genus"] == "Homo"
+    assert human.rank_name_dictionary["family"] == "Hominidae"
+    assert human.rank_name_dictionary["domain"] == "Eukaryota"
+    assert human.parent(ncbi_taxdb).taxid == 9605
+
+
+@pytest.mark.network
+def test_taxon_supports_legacy_taxids(ncbi_taxdb):
+    legacy_taxid, current_taxid = next(iter(ncbi_taxdb.oldtaxid2newtaxid.items()))
+
+    legacy_taxon = taxopy.Taxon(legacy_taxid, ncbi_taxdb)
+    current_taxon = taxopy.Taxon(current_taxid, ncbi_taxdb)
+
+    assert legacy_taxon.legacy_taxid is True
+    assert legacy_taxon.name == current_taxon.name
+    assert legacy_taxon.rank == current_taxon.rank
+    assert legacy_taxon.taxid_lineage[1:] == current_taxon.taxid_lineage[1:]
+
+
+@pytest.mark.network
+def test_taxon_rejects_invalid_taxids(ncbi_taxdb):
+    with pytest.raises(TaxidError, match="not a valid NCBI taxonomic identifier"):
+        taxopy.Taxon(-1, ncbi_taxdb)

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,0 +1,68 @@
+import pytest
+
+import taxopy
+from taxopy.exceptions import LCAError, MajorityVoteError
+
+
+@pytest.mark.network
+def test_taxid_from_name_handles_exact_matches_homonyms_and_missing_names(ncbi_taxdb):
+    assert taxopy.taxid_from_name("Homo sapiens", ncbi_taxdb) == [9606]
+    assert sorted(taxopy.taxid_from_name("Aotus", ncbi_taxdb)) == [9504, 114498]
+
+    with pytest.warns(Warning, match="not found in the taxonomy database"):
+        assert taxopy.taxid_from_name(
+            ["Homininae", "definitely-not-a-real-taxon"], ncbi_taxdb
+        ) == [
+            [207598],
+            [],
+        ]
+
+
+@pytest.mark.network
+def test_find_lca_returns_the_lowest_shared_taxon(ncbi_taxdb):
+    human = taxopy.Taxon(9606, ncbi_taxdb)
+    lagomorpha = taxopy.Taxon(9975, ncbi_taxdb)
+
+    lca = taxopy.find_lca([human, lagomorpha], ncbi_taxdb)
+
+    assert lca.taxid == 314146
+    assert lca.name == "Euarchontoglires"
+
+
+@pytest.mark.network
+def test_find_lca_requires_multiple_taxa(ncbi_taxdb):
+    human = taxopy.Taxon(9606, ncbi_taxdb)
+
+    with pytest.raises(LCAError, match="at least two Taxon objects"):
+        taxopy.find_lca([human], ncbi_taxdb)
+
+
+@pytest.mark.network
+def test_find_majority_vote_supports_unweighted_and_weighted_consensus(ncbi_taxdb):
+    human = taxopy.Taxon(9606, ncbi_taxdb)
+    gorilla = taxopy.Taxon(9593, ncbi_taxdb)
+    lagomorpha = taxopy.Taxon(9975, ncbi_taxdb)
+    yeast = taxopy.Taxon(4930, ncbi_taxdb)
+
+    majority_vote = taxopy.find_majority_vote([human, gorilla, lagomorpha], ncbi_taxdb)
+    weighted_majority_vote = taxopy.find_majority_vote(
+        [yeast, human, gorilla, lagomorpha],
+        ncbi_taxdb,
+        weights=[3, 1, 1, 1],
+    )
+
+    assert majority_vote.taxid == 207598
+    assert majority_vote.name == "Homininae"
+    assert weighted_majority_vote.name == "Opisthokonta"
+
+
+@pytest.mark.network
+def test_find_majority_vote_validates_inputs(ncbi_taxdb):
+    human = taxopy.Taxon(9606, ncbi_taxdb)
+    gorilla = taxopy.Taxon(9593, ncbi_taxdb)
+
+    with pytest.raises(MajorityVoteError, match="greater than 0.0 and less than 1"):
+        taxopy.find_majority_vote([human, gorilla], ncbi_taxdb, fraction=1.0)
+
+    with pytest.raises(MajorityVoteError, match="same length"):
+        taxopy.find_majority_vote([human, gorilla], ncbi_taxdb, weights=[1.0])


### PR DESCRIPTION
This pull request introduces two new folders and a new github-actions workflow to the repo:

- `tests`: implemented with `pytest`, which has been added as an optional dependency via `pyproject.toml`. Needs revising to ensure all important functionality is being tested
- `paper`: contains the JOSS formatted `paper.md` and `paper.bib`
- `.github/workflows/draft-pdf.yml`: github-action from the JOSS docs ensuring the paper builds and conforms to journal styling

Paper and tests should be revised accordingly before submission as this is a first draft

## Summary by Sourcery

Add a JOSS manuscript for Taxopy, introduce a pytest-based test suite with network-aware integration tests, and configure automation and documentation for testing and paper PDF generation.

New Features:
- Add JOSS-formatted paper manuscript and bibliography files under the paper directory.
- Introduce a pytest-based test suite covering core TaxDb/Taxon behavior and LCA/majority vote utilities, including optional network-dependent tests.

Enhancements:
- Document multiple installation methods (pip, uv, conda, pixi, mamba) and add guidance on running unit and integration tests in the README.
- Configure pytest defaults in pyproject.toml and add a dedicated optional test dependency group.

CI:
- Add a GitHub Actions workflow to build and upload a draft PDF of the JOSS paper on changes to the paper or workflow files.